### PR TITLE
Add parametrization to configuration file

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { RavenMatrixPage } from "@/pages/RavenMatrixPage.tsx";
+import { config } from "@pocopi/config";
 import { JSX, useState } from "react";
 
 enum Page {
@@ -7,12 +8,12 @@ enum Page {
 }
 
 export default function App(): JSX.Element {
-  const [protocol] = useState<string>("control");
+  const [group] = useState(config.sampleGroup());
   const [page, setPage] = useState<Page>(Page.RAVEN_MATRIX);
 
   switch (page) {
     case Page.RAVEN_MATRIX:
-      return <RavenMatrixPage protocol={protocol} goToNextPage={() => setPage(Page.END)}/>;
+      return <RavenMatrixPage group={group} goToNextPage={() => setPage(Page.END)}/>;
     case Page.END:
       return <span>Thanks!</span>;
   }

--- a/apps/frontend/src/pages/RavenMatrixPage.tsx
+++ b/apps/frontend/src/pages/RavenMatrixPage.tsx
@@ -1,20 +1,20 @@
-import { config } from "@pocopi/config";
+import { Group } from "@pocopi/config";
 import { useState } from "react";
 import styles from "./RavenMatrixPage.module.css";
 
 type RavenMatrixPageProps = {
-  protocol: string;
+  group: Group;
   goToNextPage: () => void;
 };
 
-export function RavenMatrixPage({ protocol, goToNextPage }: RavenMatrixPageProps) {
+export function RavenMatrixPage({ group, goToNextPage }: RavenMatrixPageProps) {
   const [phase, setPhase] = useState<number>(0);
   const [question, setQuestion] = useState<number>(0);
   const [selected, setSelected] = useState<string>("");
 
-  const { phases } = config.protocols[protocol];
+  const { phases } = group.protocol;
   const { questions } = phases[phase];
-  const { img, options: tempOptions } = questions[question];
+  const { image, options: tempOptions } = questions[question];
 
   const options = tempOptions.map(option => {
     const base64 = option.src.split(";")[1].slice(7);
@@ -66,7 +66,7 @@ export function RavenMatrixPage({ protocol, goToNextPage }: RavenMatrixPageProps
 
   return <div className={styles.ravenMatrixPage}>
     <div className={styles.ravenMatrixContainer} draggable={false}>
-      <img className={styles.ravenMatrix} src={img.src} alt={img.alt} draggable={false}/>
+      <img className={styles.ravenMatrix} src={image.src} alt={image.alt} draggable={false}/>
       <div
         className={styles.ravenOptionsContainer}
         draggable={false}

--- a/config/config-schema.json
+++ b/config/config-schema.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "JSON schema for PoCoPI's configuration file",
+  "title": "JSON schema for PoCoPI's configuration file.",
   "type": "object",
   "properties": {
     "groups": {
       "type": "object",
-      "description": "List of test groups",
+      "description": "List of test groups.",
       "patternProperties": {
         "^\\w+$": {
           "$ref": "#/$defs/group"
@@ -16,7 +16,7 @@
     },
     "protocols": {
       "type": "object",
-      "description": "List of protocols the test groups will use",
+      "description": "List of protocols the test groups will use.",
       "patternProperties": {
         "^\\w+$": {
           "$ref": "#/$defs/protocol"
@@ -27,13 +27,14 @@
     }
   },
   "required": [
-    "groups"
+    "groups",
+    "protocols"
   ],
   "additionalProperties": false,
   "$defs": {
     "group": {
       "type": "object",
-      "description": "A test group",
+      "description": "A test group.",
       "properties": {
         "probability": {
           "type": "number",
@@ -43,7 +44,7 @@
         },
         "protocol": {
           "type": "string",
-          "description": "Name of the protocol to use",
+          "description": "Name of the protocol to use.",
           "minLength": 1
         }
       },
@@ -55,17 +56,17 @@
     },
     "image": {
       "type": "object",
-      "description": "An image",
+      "description": "An image.",
       "properties": {
         "src": {
           "type": "string",
-          "description": "Where the image is located",
+          "description": "Where the image is located.",
           "format": "uri-reference",
           "minLength": 1
         },
         "alt": {
           "type": "string",
-          "description": "Needed for accessibility reasons (screen readers, image loading failure, etc.)"
+          "description": "Needed for accessibility reasons (screen readers, image loading failure, etc.)."
         }
       },
       "required": [
@@ -76,21 +77,21 @@
     },
     "option": {
       "type": "object",
-      "description": "An option",
+      "description": "An option.",
       "properties": {
         "src": {
           "type": "string",
-          "description": "Where the image is located",
+          "description": "Where the image is located.",
           "format": "uri-reference",
           "minLength": 1
         },
         "alt": {
           "type": "string",
-          "description": "Needed for accessibility reasons (screen readers, image loading failure, etc.)"
+          "description": "Needed for accessibility reasons (screen readers, image loading failure, etc.)."
         },
         "correct": {
           "type": "boolean",
-          "description": "Whether it's the correct option or not. Only one option should be marked as correct.",
+          "description": "Whether it's the correct option or not.",
           "default": false
         }
       },
@@ -102,26 +103,26 @@
     },
     "phase": {
       "type": "object",
-      "description": "Phase of a testing protocol",
+      "description": "Phase of a testing protocol.",
       "properties": {
         "allowPreviousQuestion": {
           "type": "boolean",
-          "description": "Whether to allow going to the previous question or not",
+          "description": "Whether to allow going to the previous question or not.",
           "default": true
         },
         "allowSkipQuestion": {
           "type": "boolean",
-          "description": "Whether to allow skipping the current question without answering it or not",
+          "description": "Whether to allow skipping the current question without answering it or not.",
           "default": true
         },
         "randomize": {
           "type": "boolean",
-          "description": "Whether to randomize the order of the questions or not",
+          "description": "Whether to randomize the order of the questions or not.",
           "default": false
         },
         "questions": {
           "type": "array",
-          "description": "List of questions",
+          "description": "List of questions.",
           "items": {
             "$ref": "#/$defs/question"
           },
@@ -135,41 +136,44 @@
     },
     "protocol": {
       "type": "object",
-      "description": "A testing protocol",
+      "description": "A testing protocol.",
       "properties": {
         "allowPreviousPhase": {
           "type": "boolean",
-          "description": "Whether to allow going to the previous phase or not",
+          "description": "Whether to allow going to the previous phase or not.",
           "default": true
         },
         "allowSkipPhase": {
           "type": "boolean",
-          "description": "Whether to allow skipping the current phase without completing it or not",
+          "description": "Whether to allow skipping the current phase without completing it or not.",
           "default": true
         },
         "randomize": {
           "type": "boolean",
-          "description": "Whether to randomize the order of the phases or not",
+          "description": "Whether to randomize the order of the phases or not.",
           "default": false
         },
         "phases": {
           "type": "array",
-          "description": "Phases of the testing protocol",
+          "description": "Phases of the testing protocol.",
           "items": {
             "$ref": "#/$defs/phase"
           },
           "minLength": 2
         }
       },
+      "required": [
+        "phases"
+      ],
       "additionalProperties": false
     },
     "question": {
       "type": "object",
-      "description": "Test question",
+      "description": "A test question.",
       "properties": {
         "randomize": {
           "type": "boolean",
-          "description": "Whether to randomize the order of the options or not",
+          "description": "Whether to randomize the order of the options or not.",
           "default": false
         },
         "img": {
@@ -177,7 +181,7 @@
         },
         "options": {
           "type": "array",
-          "description": "List of options",
+          "description": "List of options.",
           "items": {
             "$ref": "#/$defs/option"
           },

--- a/config/config-schema.json
+++ b/config/config-schema.json
@@ -7,7 +7,7 @@
       "type": "object",
       "description": "List of test groups.",
       "patternProperties": {
-        "^\\w+$": {
+        "^([\\w-]+)$": {
           "$ref": "#/$defs/group"
         }
       },
@@ -18,8 +18,30 @@
       "type": "object",
       "description": "List of protocols the test groups will use.",
       "patternProperties": {
-        "^\\w+$": {
+        "^([\\w-]+)$": {
           "$ref": "#/$defs/protocol"
+        }
+      },
+      "minProperties": 1,
+      "additionalProperties": false
+    },
+    "phases": {
+      "type": "object",
+      "description": "List of phases the test protocols will use.",
+      "patternProperties": {
+        "^([\\w-]+)$": {
+          "$ref": "#/$defs/phase"
+        }
+      },
+      "minProperties": 1,
+      "additionalProperties": false
+    },
+    "questions": {
+      "type": "object",
+      "description": "List of questions the test phases will use.",
+      "patternProperties": {
+        "^([\\w-]+)$": {
+          "$ref": "#/$defs/question"
         }
       },
       "minProperties": 1,
@@ -43,9 +65,16 @@
           "maximum": 1
         },
         "protocol": {
-          "type": "string",
-          "description": "Name of the protocol to use.",
-          "minLength": 1
+          "oneOf": [
+            {
+              "$ref": "#/$defs/protocol"
+            },
+            {
+              "type": "string",
+              "description": "Name of the protocol to use.",
+              "minLength": 1
+            }
+          ]
         }
       },
       "required": [
@@ -124,9 +153,18 @@
           "type": "array",
           "description": "List of questions.",
           "items": {
-            "$ref": "#/$defs/question"
+            "oneOf": [
+              {
+                "$ref": "#/$defs/question"
+              },
+              {
+                "type": "string",
+                "description": "Name of the test question to use.",
+                "minLength": 1
+              }
+            ]
           },
-          "minLength": 2
+          "minLength": 1
         }
       },
       "required": [
@@ -157,9 +195,18 @@
           "type": "array",
           "description": "Phases of the testing protocol.",
           "items": {
-            "$ref": "#/$defs/phase"
+            "oneOf": [
+              {
+                "$ref": "#/$defs/phase"
+              },
+              {
+                "type": "string",
+                "description": "Name of the test phase to use.",
+                "minLength": 1
+              }
+            ]
           },
-          "minLength": 2
+          "minLength": 1
         }
       },
       "required": [
@@ -185,7 +232,7 @@
           "items": {
             "$ref": "#/$defs/option"
           },
-          "minLength": 2
+          "minLength": 1
         }
       },
       "required": [

--- a/config/config-schema.json
+++ b/config/config-schema.json
@@ -104,6 +104,21 @@
       "type": "object",
       "description": "Phase of a testing protocol",
       "properties": {
+        "allowPreviousQuestion": {
+          "type": "boolean",
+          "description": "Whether to allow going to the previous question or not",
+          "default": true
+        },
+        "allowSkipQuestion": {
+          "type": "boolean",
+          "description": "Whether to allow skipping the current question without answering it or not",
+          "default": true
+        },
+        "randomize": {
+          "type": "boolean",
+          "description": "Whether to randomize the order of the questions or not",
+          "default": false
+        },
         "questions": {
           "type": "array",
           "description": "List of questions",
@@ -122,6 +137,21 @@
       "type": "object",
       "description": "A testing protocol",
       "properties": {
+        "allowPreviousPhase": {
+          "type": "boolean",
+          "description": "Whether to allow going to the previous phase or not",
+          "default": true
+        },
+        "allowSkipPhase": {
+          "type": "boolean",
+          "description": "Whether to allow skipping the current phase without completing it or not",
+          "default": true
+        },
+        "randomize": {
+          "type": "boolean",
+          "description": "Whether to randomize the order of the phases or not",
+          "default": false
+        },
         "phases": {
           "type": "array",
           "description": "Phases of the testing protocol",
@@ -137,6 +167,11 @@
       "type": "object",
       "description": "Test question",
       "properties": {
+        "randomize": {
+          "type": "boolean",
+          "description": "Whether to randomize the order of the options or not",
+          "default": false
+        },
         "img": {
           "$ref": "#/$defs/image"
         },

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -224,6 +224,64 @@ protocols:
                 alt: option 5
               - src: groupB1_option6.webp
                 alt: option 6
+          - randomize: true
+            img:
+              src: groupB2.webp
+              alt: question image
+            options:
+              - src: groupB2_option1.webp
+                alt: option 1
+                correct: true
+              - src: groupB2_option2.webp
+                alt: option 2
+              - src: groupB2_option3.webp
+                alt: option 3
+              - src: groupB2_option4.webp
+                alt: option 4
+              - src: groupB2_option5.webp
+                alt: option 5
+              - src: groupB2_option6.webp
+                alt: option 6
+      - allowPreviousQuestion: true
+        allowSkipQuestion: true
+        randomize: true
+        questions:
+          - randomize: true
+            img:
+              src: groupA1.webp
+              alt: question image
+            options:
+              - src: groupA1_option1.webp
+                alt: option 1
+                correct: true
+              - src: groupA1_option2.webp
+                alt: option 2
+              - src: groupA1_option3.webp
+                alt: option 3
+              - src: groupA1_option4.webp
+                alt: option 4
+              - src: groupA1_option5.webp
+                alt: option 5
+              - src: groupA1_option6.webp
+                alt: option 6
+          - randomize: true
+            img:
+              src: groupA2.webp
+              alt: question image
+            options:
+              - src: groupA2_option1.webp
+                alt: option 1
+                correct: true
+              - src: groupA2_option2.webp
+                alt: option 2
+              - src: groupA2_option3.webp
+                alt: option 3
+              - src: groupA2_option4.webp
+                alt: option 4
+              - src: groupA2_option5.webp
+                alt: option 5
+              - src: groupA2_option6.webp
+                alt: option 6
       - control-phase1
 
 phases:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2,13 +2,13 @@
 
 groups:
   control:
-    probability: 0.4
+    probability: 0.3
     protocol: control
   groupA:
-    probability: 0.3
+    probability: 0.5
     protocol: groupA
   groupB:
-    probability: 0.3
+    probability: 0.2
     protocol: groupB
 
 protocols:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,47 +8,16 @@ groups:
     probability: 0.5
     protocol: groupA
   groupB:
-    probability: 0.2
+    probability: 0.15
     protocol: groupB
+  groupC:
+    probability: 0.05
+    protocol: groupC
 
 protocols:
   control:
     phases:
-      - questions:
-        - img:
-            src: control1.webp
-            alt: question image
-          options:
-            - src: control1_option1.webp
-              alt: option 1
-              correct: true
-            - src: control1_option2.webp
-              alt: option 2
-            - src: control1_option3.webp
-              alt: option 3
-            - src: control1_option4.webp
-              alt: option 4
-            - src: control1_option5.webp
-              alt: option 5
-            - src: control1_option6.webp
-              alt: option 6
-        - img:
-            src: control2.webp
-            alt: question image
-          options:
-            - src: control2_option1.webp
-              alt: option 1
-            - src: control2_option2.webp
-              alt: option 2
-              correct: true
-            - src: control2_option3.webp
-              alt: option 3
-            - src: control2_option4.webp
-              alt: option 4
-            - src: control2_option5.webp
-              alt: option 5
-            - src: control2_option6.webp
-              alt: option 6
+      - control-phase1
       - questions:
         - img:
             src: control3.webp
@@ -228,3 +197,73 @@ protocols:
               alt: option 5
             - src: groupB4_option6.webp
               alt: option 6
+  groupC:
+    allowPreviousPhase: false
+    allowSkipPhase: false
+    randomize: true
+    phases:
+      - allowPreviousQuestion: false
+        allowSkipQuestion: false
+        randomize: true
+        questions:
+          - randomize: true
+            img:
+              src: groupB1.webp
+              alt: question image
+            options:
+              - src: groupB1_option1.webp
+                alt: option 1
+                correct: true
+              - src: groupB1_option2.webp
+                alt: option 2
+              - src: groupB1_option3.webp
+                alt: option 3
+              - src: groupB1_option4.webp
+                alt: option 4
+              - src: groupB1_option5.webp
+                alt: option 5
+              - src: groupB1_option6.webp
+                alt: option 6
+      - control-phase1
+
+phases:
+  control-phase1:
+    questions:
+      - control-phase1-question1
+      - img:
+          src: control2.webp
+          alt: question image
+        options:
+          - src: control2_option1.webp
+            alt: option 1
+          - src: control2_option2.webp
+            alt: option 2
+            correct: true
+          - src: control2_option3.webp
+            alt: option 3
+          - src: control2_option4.webp
+            alt: option 4
+          - src: control2_option5.webp
+            alt: option 5
+          - src: control2_option6.webp
+            alt: option 6
+
+questions:
+  control-phase1-question1:
+    img:
+      src: control1.webp
+      alt: question image
+    options:
+      - src: control1_option1.webp
+        alt: option 1
+        correct: true
+      - src: control1_option2.webp
+        alt: option 2
+      - src: control1_option3.webp
+        alt: option 3
+      - src: control1_option4.webp
+        alt: option 4
+      - src: control1_option5.webp
+        alt: option 5
+      - src: control1_option6.webp
+        alt: option 6

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -43,7 +43,7 @@ export class Config {
 
     public sampleGroup(): Group {
         const randomValue = crypto.getRandomValues(new Uint32Array(1))[0]!;
-        const targetProbability = new Decimal(randomValue.toString().replace(/^\d(\d+)$/, "0.$1"));
+        const targetProbability = new Decimal("0." + randomValue.toString().split("").reverse().join(""));
 
         const n = this.probabilitySums.length;
         let left = 0, right = n - 1;

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -33,7 +33,7 @@ export class Config {
     private readonly probabilitySums: readonly Decimal[];
 
     public constructor(config: FlatRawConfig) {
-        this.groups = Object.freeze(this.parseGroups(config));
+        this.groups = Object.freeze(parseGroups(config));
 
         const probabilitySums: Decimal[] = [];
         let lastProbability = new Decimal(0);
@@ -70,16 +70,16 @@ export class Config {
 
         return makeGroup(this.groups[index]!);
     }
+}
 
-    private parseGroups(config: FlatRawConfig): readonly FlatRawGroupWithLabel[] {
-        const groups = Object.entries(config.groups)
-            .map<FlatRawGroupWithLabel>(([label, group]) => ({
-                ...group,
-                label,
-            }));
+function parseGroups(config: FlatRawConfig): readonly FlatRawGroupWithLabel[] {
+    const groups = Object.entries(config.groups)
+        .map<FlatRawGroupWithLabel>(([label, group]) => ({
+            ...group,
+            label,
+        }));
 
-        return groups.sort((a, b) => new Decimal(a.probability).comparedTo(b.probability));
-    }
+    return groups.sort((a, b) => new Decimal(a.probability).comparedTo(b.probability));
 }
 
 function makeGroup(group: FlatRawGroupWithLabel): Group {

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -1,0 +1,169 @@
+import Decimal from "decimal.js";
+import { shuffle } from "./shuffle";
+import { RawConfig, RawGroup, RawOption, RawPhase, RawProtocol, RawQuestion } from "./types";
+
+const defaults = Object.freeze({
+    protocol: Object.freeze({
+        allowPreviousPhase: true,
+        allowSkipPhase: true,
+        randomize: false,
+    } satisfies Partial<RawProtocol>),
+    phase: Object.freeze({
+        allowPreviousQuestion: true,
+        allowSkipQuestion: true,
+        randomize: false,
+    } satisfies Partial<RawPhase>),
+    question: Object.freeze({
+        randomize: false,
+    } satisfies Partial<RawQuestion>),
+    option: Object.freeze({
+        correct: false,
+    } satisfies Partial<RawOption>),
+});
+
+export class Config {
+    private readonly groups: readonly Group[];
+    private readonly probabilitySums: readonly Decimal[];
+
+    public constructor(rawConfig: RawConfig) {
+        this.groups = Object.freeze(this.parseGroups(rawConfig));
+
+        const probabilitySums: Decimal[] = [];
+        let lastProbability = new Decimal(0);
+
+        for (const { probability } of this.groups) {
+            lastProbability = lastProbability.add(probability);
+            probabilitySums.push(lastProbability);
+        }
+
+        this.probabilitySums = Object.freeze(probabilitySums);
+
+        Object.freeze(this);
+    }
+
+    public sampleGroup(): Group {
+        const randomValue = crypto.getRandomValues(new Uint32Array(1))[0]!;
+        const targetProbability = new Decimal(randomValue.toString().replace(/^\d(\d+)$/, "0.$1"));
+
+        const n = this.probabilitySums.length;
+        let left = 0, right = n - 1;
+        let index = 0;
+
+        while (left <= right) {
+            const mid = left + Math.floor((right - left) / 2);
+            const value = this.probabilitySums[mid]!;
+
+            if (value.greaterThan(targetProbability)) {
+                index = mid;
+                right = mid - 1;
+            } else {
+                left = mid + 1;
+            }
+        }
+
+        return this.groups[index]!;
+    }
+
+    private parseGroups(rawConfig: RawConfig): Group[] {
+        const groups: Group[] = [];
+
+        for (const [groupLabel, rawGroup] of Object.entries(rawConfig.groups)) {
+            const rawProtocol = rawConfig.protocols[rawGroup.protocol]!;
+            const group = new Group(groupLabel, rawGroup, rawProtocol);
+            groups.push(group);
+        }
+
+        return groups.sort((a, b) => a.probability.comparedTo(b.probability));
+    }
+}
+
+export class Group {
+    public readonly label: string;
+    public readonly probability: Decimal;
+    public readonly protocol: Protocol;
+
+    public constructor(label: string, rawGroup: RawGroup, rawProtocol: RawProtocol) {
+        this.label = label;
+        this.probability = new Decimal(rawGroup.probability);
+        this.protocol = new Protocol(rawGroup.protocol, rawProtocol);
+        Object.freeze(this);
+    }
+}
+
+export class Protocol {
+    public readonly label: string;
+    public readonly allowPreviousPhase: boolean;
+    public readonly allowSkipPhase: boolean;
+
+    private readonly randomize: boolean;
+    private readonly phases: readonly Phase[];
+
+    public constructor(label: string, rawProtocol: RawProtocol) {
+        this.label = label;
+        this.phases = Object.freeze(rawProtocol.phases.map(p => new Phase(p)));
+        this.randomize = rawProtocol.randomize ?? defaults.protocol.randomize;
+        this.allowPreviousPhase = rawProtocol.allowPreviousPhase ?? defaults.protocol.allowPreviousPhase;
+        this.allowSkipPhase = rawProtocol.allowSkipPhase ?? defaults.protocol.allowSkipPhase;
+        Object.freeze(this);
+    }
+
+    public getPhases(): readonly Phase[] {
+        return this.randomize
+            ? Object.freeze(shuffle(this.phases.map(o => o)))
+            : this.phases;
+    }
+}
+
+export class Phase {
+    public readonly allowPreviousQuestion: boolean;
+    public readonly allowSkipQuestion: boolean;
+
+    private readonly randomize: boolean;
+    private readonly questions: readonly Question[];
+
+    public constructor(rawPhase: RawPhase) {
+        this.questions = Object.freeze(rawPhase.questions.map(q => new Question(q)));
+        this.randomize = rawPhase.randomize ?? defaults.phase.randomize;
+        this.allowPreviousQuestion = rawPhase.allowPreviousQuestion ?? defaults.phase.allowPreviousQuestion;
+        this.allowSkipQuestion = rawPhase.allowSkipQuestion ?? defaults.phase.allowSkipQuestion;
+        Object.freeze(this);
+    }
+
+    public getQuestions(): readonly Question[] {
+        return this.randomize
+            ? Object.freeze(shuffle(this.questions.map(o => o)))
+            : this.questions;
+    }
+}
+
+export class Question {
+    public readonly image: Image;
+
+    private readonly randomize: boolean;
+    private readonly options: readonly Option[];
+
+    public constructor(rawQuestion: RawQuestion) {
+        this.image = Object.freeze(rawQuestion.img);
+        this.options = Object.freeze(rawQuestion.options.map(o => Object.freeze<Option>({
+            ...defaults.option,
+            ...o,
+        })));
+        this.randomize = rawQuestion.randomize ?? defaults.question.randomize;
+        Object.freeze(this);
+    }
+
+    public getOptions(): readonly Option[] {
+        return this.randomize
+            ? Object.freeze(shuffle(this.options.map(o => o)))
+            : this.options;
+    }
+}
+
+export type Option = Image & {
+    readonly correct: boolean;
+};
+
+export type Image = {
+    readonly src: string;
+    readonly alt: string;
+};

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -52,8 +52,8 @@ export class Config {
         const randomValue = crypto.getRandomValues(new Uint32Array(1))[0]!;
         const targetProbability = new Decimal("0." + randomValue.toString().split("").reverse().join(""));
 
-        const n = this.probabilitySums.length;
-        let left = 0, right = n - 1;
+        let left = 0;
+        let right = this.probabilitySums.length - 1;
         let index = 0;
 
         while (left <= right) {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -65,7 +65,7 @@ function validateConfig(config: PoCoPIConfig): PoCoPIConfig {
         const protocolUsedAt = usedProtocols.get(protocol);
 
         if (protocolUsedAt) {
-            throw new Error(`Protocol '${protocol}' already used at ${protocolUsedAt}.`);
+            console.warn(`Protocol '${protocol}' already used at ${protocolUsedAt}.`);
         }
 
         probabilitySum = probabilitySum.add(probability);
@@ -105,7 +105,7 @@ function validateConfig(config: PoCoPIConfig): PoCoPIConfig {
         const usedQuestionImageAt = usedImages.get(questionImage);
 
         if (usedQuestionImageAt) {
-            throw new Error(`Image '${questionImage}' already used at ${usedQuestionImageAt}.`);
+            console.warn(`Image '${questionImage}' already used at ${usedQuestionImageAt}.`);
         }
 
         const questionImagePath = imageNameToPath.get(questionImage);
@@ -124,7 +124,7 @@ function validateConfig(config: PoCoPIConfig): PoCoPIConfig {
             const usedOptionImageAt = usedImages.get(optionImage);
 
             if (usedOptionImageAt) {
-                throw new Error(`Image '${optionImage}' already used at ${usedOptionImageAt}.`);
+                console.warn(`Image '${optionImage}' already used at ${usedOptionImageAt}.`);
             }
 
             const optionImagePath = imageNameToPath.get(optionImage);
@@ -140,14 +140,14 @@ function validateConfig(config: PoCoPIConfig): PoCoPIConfig {
             }
 
             if (foundCorrect !== -1) {
-                throw new Error(`${path}.options[${foundCorrect}] was already marked as correct.`);
+                console.warn(`${path}.options[${foundCorrect}] was already marked as correct.`);
             }
 
             foundCorrect = k;
         }
 
         if (foundCorrect === -1) {
-            throw new Error(`Could not find an option marked as correct in ${path}.`);
+            console.warn(`Could not find an option marked as correct in ${path}.`);
         }
     }
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -5,7 +5,7 @@ import mime from "mime";
 import path from "path";
 import yaml from "yaml";
 import { Config } from "./config";
-import { FlatRawConfig, RawConfig, RawPhase, RawProtocol, RawQuestion } from "./types";
+import { FlatRawConfig, RawConfig, RawPhase, RawProtocol, RawQuestion } from "./raw-types";
 
 const CONFIG_DIR = path.join(__dirname, "../../../config");
 const CONFIG_YAML_PATH = path.join(CONFIG_DIR, "config.yaml");

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -4,12 +4,28 @@ import { Validator } from "jsonschema";
 import mime from "mime";
 import path from "path";
 import yaml from "yaml";
-import { Image, PoCoPIConfig } from "./types";
+import { Image, PhaseQuestion, PoCoPIConfig, Protocol, ProtocolPhase } from "./types";
 
 const CONFIG_DIR = path.join(__dirname, "../../../config");
 const CONFIG_YAML_PATH = path.join(CONFIG_DIR, "config.yaml");
 const CONFIG_JSON_SCHEMA_PATH = path.join(CONFIG_DIR, "config-schema.json");
 const IMAGES_DIR = path.join(CONFIG_DIR, "images");
+
+const defaults = Object.freeze({
+    protocol: Object.freeze({
+        allowPreviousPhase: true,
+        allowSkipPhase: true,
+        randomize: false,
+    } satisfies Partial<Protocol>),
+    phase: Object.freeze({
+        allowPreviousQuestion: true,
+        allowSkipQuestion: true,
+        randomize: false,
+    } satisfies Partial<ProtocolPhase>),
+    question: Object.freeze({
+        randomize: false,
+    } satisfies Partial<PhaseQuestion>),
+});
 
 export const config = getConfig();
 
@@ -84,12 +100,18 @@ function validateConfig(config: PoCoPIConfig): PoCoPIConfig {
     const iterator = {
         * [Symbol.iterator]() {
             for (const [label, protocol] of Object.entries(config.protocols)) {
+                Object.assign(protocol, { ...defaults.protocol, ...protocol });
+
                 for (let i = 0; i < protocol.phases.length; i++) {
                     const phase = protocol.phases[i]!;
+
+                    Object.assign(phase, { ...defaults.phase, ...phase });
 
                     for (let j = 0; j < phase.questions.length; j++) {
                         const question = phase.questions[j]!;
                         const path = `protocols.${label}.phases[${i}].questions[${j}]`;
+
+                        Object.assign(question, { ...defaults.question, ...question });
 
                         yield { path, question };
                     }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -130,9 +130,8 @@ function flattenConfig(config: RawConfig): FlatRawConfig {
 
 function validateConfig(config: FlatRawConfig): FlatRawConfig {
     const probabilitySum = Object.values(config.groups).reduce((a, b) => a.add(b.probability), new Decimal(0));
-    console.log(probabilitySum.toString());
     if (probabilitySum.lessThan(1)) {
-        throw new Error("The sum of all the group probabilities should be 1.");
+        throw new Error(`The sum of all the group probabilities should be 1. Got ${probabilitySum.toString()}`);
     }
 
     const usedImages = new Map<string, string>();

--- a/packages/config/src/raw-types.ts
+++ b/packages/config/src/raw-types.ts
@@ -1,45 +1,59 @@
 export type FlatRawConfig = {
     groups: Record<string, FlatRawGroup>;
 };
+
 export type RawConfig = {
     groups: Record<string, RawGroup>;
     protocols?: Record<string, RawProtocol>;
     phases?: Record<string, RawPhase>;
     questions?: Record<string, RawQuestion>;
 };
+
+export type FlatRawGroupWithLabel = FlatRawGroup & {
+    label: string;
+};
+
 export type FlatRawGroup = Omit<RawGroup, "protocol"> & {
     protocol: FlatRawProtocol;
 };
+
 export type RawGroup = {
     probability: number;
     protocol: string | RawProtocol;
 };
+
 export type FlatRawProtocol = Omit<RawProtocol, "phases"> & {
     phases: FlatRawPhase[];
 };
+
 export type RawProtocol = {
     allowPreviousPhase?: boolean;
     allowSkipPhase?: boolean;
     randomize?: boolean;
     phases: Array<RawPhase | string>;
 };
+
 export type FlatRawPhase = Omit<RawPhase, "questions"> & {
     questions: RawQuestion[];
 };
+
 export type RawPhase = {
     allowPreviousQuestion?: boolean;
     allowSkipQuestion?: boolean;
     randomize?: boolean;
     questions: Array<RawQuestion | string>;
 };
+
 export type RawQuestion = {
     randomize?: boolean;
     img: RawImage;
     options: RawOption[];
 };
+
 export type RawOption = RawImage & {
     correct?: boolean;
 };
+
 export type RawImage = {
     src: string;
     alt: string;

--- a/packages/config/src/shuffle.ts
+++ b/packages/config/src/shuffle.ts
@@ -14,7 +14,7 @@ export function shuffle<T>(array: T[]): T[] {
 function randomIndex(max: number): number {
     const { bytesNeeded, mask } = calculateParameters(max);
     const randomBytes = new Uint8Array(bytesNeeded);
-    let randomValue = 0;
+    let randomValue = max + 1;
 
     while (randomValue > max) {
         randomValue = 0;

--- a/packages/config/src/shuffle.ts
+++ b/packages/config/src/shuffle.ts
@@ -1,0 +1,53 @@
+// Adapted from https://github.com/dhessler/crypto-secure-shuffle
+export function shuffle<T>(array: T[]): T[] {
+    for (let i = array.length - 1; i > 0; i--) {
+        const j = randomIndex(array.length - 1);
+        const temp = array[i]!;
+        array[i] = array[j]!;
+        array[j] = temp;
+    }
+
+    return array;
+}
+
+// Adapted from https://www.npmjs.com/package/random-number-csprng
+function randomIndex(max: number): number {
+    const { bytesNeeded, mask } = calculateParameters(max);
+    const randomBytes = new Uint8Array(bytesNeeded);
+    let randomValue = 0;
+
+    while (randomValue > max) {
+        randomValue = 0;
+        crypto.getRandomValues(randomBytes);
+
+        for (let i = 0; i < bytesNeeded; i++) {
+            randomValue |= (randomBytes[i]! << (8 * i));
+        }
+
+        randomValue &= mask;
+    }
+
+    return randomValue;
+}
+
+function calculateParameters(range: number): {
+    bytesNeeded: number;
+    mask: number;
+} {
+    let bitsNeeded = 0;
+    let bytesNeeded = 0;
+    let mask = 1;
+
+    while (range > 0) {
+        if (bitsNeeded % 8 === 0) {
+            bytesNeeded += 1;
+        }
+
+        bitsNeeded += 1;
+        mask = mask << 1 | 1;
+
+        range >>>= 1;
+    }
+
+    return { bytesNeeded, mask };
+}

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1,35 +1,38 @@
-export type PoCoPIConfig = {
-    readonly groups: Readonly<Record<string, Group>>;
-    readonly protocols: Readonly<Record<string, Protocol>>;
+export type RawConfig = {
+    groups: Record<string, RawGroup>;
+    protocols: Record<string, RawProtocol>;
 };
 
-export type Group = {
-    readonly probability: number;
-    readonly protocol: string;
+export type RawGroup = {
+    probability: number;
+    protocol: string;
 };
 
-export type Protocol = {
-    readonly allowPreviousPhase: boolean;
-    readonly allowSkipPhase: boolean;
-    readonly randomize: boolean;
-    readonly phases: readonly ProtocolPhase[];
+export type RawProtocol = {
+    allowPreviousPhase?: boolean;
+    allowSkipPhase?: boolean;
+    randomize?: boolean;
+    phases: RawPhase[];
 };
 
-export type ProtocolPhase = {
-    readonly allowPreviousQuestion: boolean;
-    readonly allowSkipQuestion: boolean;
-    readonly randomize: boolean;
-    readonly questions: readonly PhaseQuestion[];
+export type RawPhase = {
+    allowPreviousQuestion?: boolean;
+    allowSkipQuestion?: boolean;
+    randomize?: boolean;
+    questions: RawQuestion[];
 };
 
-export type PhaseQuestion = {
-    readonly randomize: boolean;
-    readonly img: Image;
-    readonly options: readonly Image[];
+export type RawQuestion = {
+    randomize?: boolean;
+    img: RawImage;
+    options: RawOption[];
 };
 
-export type Image = {
-    readonly src: string;
-    readonly alt: string;
-    readonly correct?: boolean;
+export type RawOption = RawImage & {
+    correct?: boolean;
+};
+
+export type RawImage = {
+    src: string;
+    alt: string;
 };

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1,6 +1,6 @@
 export type PoCoPIConfig = {
-    readonly groups: Record<string, Group>;
-    readonly protocols: Record<string, Protocol>;
+    readonly groups: Readonly<Record<string, Group>>;
+    readonly protocols: Readonly<Record<string, Protocol>>;
 };
 
 export type Group = {
@@ -9,14 +9,21 @@ export type Group = {
 };
 
 export type Protocol = {
+    readonly allowPreviousPhase: boolean;
+    readonly allowSkipPhase: boolean;
+    readonly randomize: boolean;
     readonly phases: readonly ProtocolPhase[];
 };
 
 export type ProtocolPhase = {
+    readonly allowPreviousQuestion: boolean;
+    readonly allowSkipQuestion: boolean;
+    readonly randomize: boolean;
     readonly questions: readonly PhaseQuestion[];
 };
 
 export type PhaseQuestion = {
+    readonly randomize: boolean;
     readonly img: Image;
     readonly options: readonly Image[];
 };

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1,25 +1,43 @@
+export type FlatRawConfig = {
+    groups: Record<string, FlatRawGroup>;
+};
+
 export type RawConfig = {
     groups: Record<string, RawGroup>;
-    protocols: Record<string, RawProtocol>;
+    protocols?: Record<string, RawProtocol>;
+    phases?: Record<string, RawPhase>;
+    questions?: Record<string, RawQuestion>;
+};
+
+export type FlatRawGroup = Omit<RawGroup, "protocol"> & {
+    protocol: FlatRawProtocol;
 };
 
 export type RawGroup = {
     probability: number;
-    protocol: string;
+    protocol: string | RawProtocol;
+};
+
+export type FlatRawProtocol = Omit<RawProtocol, "phases"> & {
+    phases: FlatRawPhase[];
 };
 
 export type RawProtocol = {
     allowPreviousPhase?: boolean;
     allowSkipPhase?: boolean;
     randomize?: boolean;
-    phases: RawPhase[];
+    phases: Array<RawPhase | string>;
+};
+
+export type FlatRawPhase = Omit<RawPhase, "questions"> & {
+    questions: RawQuestion[];
 };
 
 export type RawPhase = {
     allowPreviousQuestion?: boolean;
     allowSkipQuestion?: boolean;
     randomize?: boolean;
-    questions: RawQuestion[];
+    questions: Array<RawQuestion | string>;
 };
 
 export type RawQuestion = {

--- a/packages/config/types/config.d.ts
+++ b/packages/config/types/config.d.ts
@@ -1,0 +1,46 @@
+import Decimal from "decimal.js";
+import { RawConfig, RawGroup, RawPhase, RawProtocol, RawQuestion } from "./types";
+export declare class Config {
+    private readonly groups;
+    private readonly probabilitySums;
+    constructor(rawConfig: RawConfig);
+    sampleGroup(): Group;
+    private parseGroups;
+}
+export declare class Group {
+    readonly label: string;
+    readonly probability: Decimal;
+    readonly protocol: Protocol;
+    constructor(label: string, rawGroup: RawGroup, rawProtocol: RawProtocol);
+}
+export declare class Protocol {
+    readonly label: string;
+    readonly allowPreviousPhase: boolean;
+    readonly allowSkipPhase: boolean;
+    private readonly randomize;
+    private readonly phases;
+    constructor(label: string, rawProtocol: RawProtocol);
+    getPhases(): readonly Phase[];
+}
+export declare class Phase {
+    readonly allowPreviousQuestion: boolean;
+    readonly allowSkipQuestion: boolean;
+    private readonly randomize;
+    private readonly questions;
+    constructor(rawPhase: RawPhase);
+    getQuestions(): readonly Question[];
+}
+export declare class Question {
+    readonly image: Image;
+    private readonly randomize;
+    private readonly options;
+    constructor(rawQuestion: RawQuestion);
+    getOptions(): readonly Option[];
+}
+export type Option = Image & {
+    readonly correct: boolean;
+};
+export type Image = {
+    readonly src: string;
+    readonly alt: string;
+};

--- a/packages/config/types/config.d.ts
+++ b/packages/config/types/config.d.ts
@@ -5,7 +5,6 @@ export declare class Config {
     private readonly probabilitySums;
     constructor(config: FlatRawConfig);
     sampleGroup(): Group;
-    private parseGroups;
 }
 export type Group = {
     readonly label: string;

--- a/packages/config/types/config.d.ts
+++ b/packages/config/types/config.d.ts
@@ -1,5 +1,5 @@
 import Decimal from "decimal.js";
-import { FlatRawConfig, FlatRawGroup, FlatRawPhase, FlatRawProtocol, RawQuestion } from "./types";
+import { FlatRawConfig } from "./raw-types";
 export declare class Config {
     private readonly groups;
     private readonly probabilitySums;
@@ -7,35 +7,25 @@ export declare class Config {
     sampleGroup(): Group;
     private parseGroups;
 }
-export declare class Group {
+export type Group = {
     readonly label: string;
     readonly probability: Decimal;
     readonly protocol: Protocol;
-    constructor(label: string, group: FlatRawGroup);
-}
-export declare class Protocol {
+};
+export type Protocol = {
     readonly allowPreviousPhase: boolean;
     readonly allowSkipPhase: boolean;
-    private readonly randomize;
-    private readonly phases;
-    constructor(protocol: FlatRawProtocol);
-    getPhases(): readonly Phase[];
-}
-export declare class Phase {
+    readonly phases: readonly Phase[];
+};
+export type Phase = {
     readonly allowPreviousQuestion: boolean;
     readonly allowSkipQuestion: boolean;
-    private readonly randomize;
-    private readonly questions;
-    constructor(phase: FlatRawPhase);
-    getQuestions(): readonly Question[];
-}
-export declare class Question {
+    readonly questions: readonly Question[];
+};
+export type Question = {
     readonly image: Image;
-    private readonly randomize;
-    private readonly options;
-    constructor(question: RawQuestion);
-    getOptions(): readonly Option[];
-}
+    readonly options: readonly Option[];
+};
 export type Option = Image & {
     readonly correct: boolean;
 };

--- a/packages/config/types/config.d.ts
+++ b/packages/config/types/config.d.ts
@@ -1,9 +1,9 @@
 import Decimal from "decimal.js";
-import { RawConfig, RawGroup, RawPhase, RawProtocol, RawQuestion } from "./types";
+import { FlatRawConfig, FlatRawGroup, FlatRawPhase, FlatRawProtocol, RawQuestion } from "./types";
 export declare class Config {
     private readonly groups;
     private readonly probabilitySums;
-    constructor(rawConfig: RawConfig);
+    constructor(config: FlatRawConfig);
     sampleGroup(): Group;
     private parseGroups;
 }
@@ -11,15 +11,14 @@ export declare class Group {
     readonly label: string;
     readonly probability: Decimal;
     readonly protocol: Protocol;
-    constructor(label: string, rawGroup: RawGroup, rawProtocol: RawProtocol);
+    constructor(label: string, group: FlatRawGroup);
 }
 export declare class Protocol {
-    readonly label: string;
     readonly allowPreviousPhase: boolean;
     readonly allowSkipPhase: boolean;
     private readonly randomize;
     private readonly phases;
-    constructor(label: string, rawProtocol: RawProtocol);
+    constructor(protocol: FlatRawProtocol);
     getPhases(): readonly Phase[];
 }
 export declare class Phase {
@@ -27,14 +26,14 @@ export declare class Phase {
     readonly allowSkipQuestion: boolean;
     private readonly randomize;
     private readonly questions;
-    constructor(rawPhase: RawPhase);
+    constructor(phase: FlatRawPhase);
     getQuestions(): readonly Question[];
 }
 export declare class Question {
     readonly image: Image;
     private readonly randomize;
     private readonly options;
-    constructor(rawQuestion: RawQuestion);
+    constructor(question: RawQuestion);
     getOptions(): readonly Option[];
 }
 export type Option = Image & {

--- a/packages/config/types/index.d.ts
+++ b/packages/config/types/index.d.ts
@@ -1,3 +1,3 @@
-import { PoCoPIConfig } from "./types";
-export declare const config: PoCoPIConfig;
-export * from "./types";
+import { Config } from "./config";
+export declare const config: Config;
+export * from "./config";

--- a/packages/config/types/raw-types.d.ts
+++ b/packages/config/types/raw-types.d.ts
@@ -1,55 +1,48 @@
 export type FlatRawConfig = {
     groups: Record<string, FlatRawGroup>;
 };
-
 export type RawConfig = {
     groups: Record<string, RawGroup>;
     protocols?: Record<string, RawProtocol>;
     phases?: Record<string, RawPhase>;
     questions?: Record<string, RawQuestion>;
 };
-
+export type FlatRawGroupWithLabel = FlatRawGroup & {
+    label: string;
+};
 export type FlatRawGroup = Omit<RawGroup, "protocol"> & {
     protocol: FlatRawProtocol;
 };
-
 export type RawGroup = {
     probability: number;
     protocol: string | RawProtocol;
 };
-
 export type FlatRawProtocol = Omit<RawProtocol, "phases"> & {
     phases: FlatRawPhase[];
 };
-
 export type RawProtocol = {
     allowPreviousPhase?: boolean;
     allowSkipPhase?: boolean;
     randomize?: boolean;
     phases: Array<RawPhase | string>;
 };
-
 export type FlatRawPhase = Omit<RawPhase, "questions"> & {
     questions: RawQuestion[];
 };
-
 export type RawPhase = {
     allowPreviousQuestion?: boolean;
     allowSkipQuestion?: boolean;
     randomize?: boolean;
     questions: Array<RawQuestion | string>;
 };
-
 export type RawQuestion = {
     randomize?: boolean;
     img: RawImage;
     options: RawOption[];
 };
-
 export type RawOption = RawImage & {
     correct?: boolean;
 };
-
 export type RawImage = {
     src: string;
     alt: string;

--- a/packages/config/types/shuffle.d.ts
+++ b/packages/config/types/shuffle.d.ts
@@ -1,0 +1,1 @@
+export declare function shuffle<T>(array: T[]): T[];

--- a/packages/config/types/types.d.ts
+++ b/packages/config/types/types.d.ts
@@ -1,22 +1,36 @@
+export type FlatRawConfig = {
+    groups: Record<string, FlatRawGroup>;
+};
 export type RawConfig = {
     groups: Record<string, RawGroup>;
-    protocols: Record<string, RawProtocol>;
+    protocols?: Record<string, RawProtocol>;
+    phases?: Record<string, RawPhase>;
+    questions?: Record<string, RawQuestion>;
+};
+export type FlatRawGroup = Omit<RawGroup, "protocol"> & {
+    protocol: FlatRawProtocol;
 };
 export type RawGroup = {
     probability: number;
-    protocol: string;
+    protocol: string | RawProtocol;
+};
+export type FlatRawProtocol = Omit<RawProtocol, "phases"> & {
+    phases: FlatRawPhase[];
 };
 export type RawProtocol = {
     allowPreviousPhase?: boolean;
     allowSkipPhase?: boolean;
     randomize?: boolean;
-    phases: RawPhase[];
+    phases: Array<RawPhase | string>;
+};
+export type FlatRawPhase = Omit<RawPhase, "questions"> & {
+    questions: RawQuestion[];
 };
 export type RawPhase = {
     allowPreviousQuestion?: boolean;
     allowSkipQuestion?: boolean;
     randomize?: boolean;
-    questions: RawQuestion[];
+    questions: Array<RawQuestion | string>;
 };
 export type RawQuestion = {
     randomize?: boolean;

--- a/packages/config/types/types.d.ts
+++ b/packages/config/types/types.d.ts
@@ -1,30 +1,32 @@
-export type PoCoPIConfig = {
-    readonly groups: Readonly<Record<string, Group>>;
-    readonly protocols: Readonly<Record<string, Protocol>>;
+export type RawConfig = {
+    groups: Record<string, RawGroup>;
+    protocols: Record<string, RawProtocol>;
 };
-export type Group = {
-    readonly probability: number;
-    readonly protocol: string;
+export type RawGroup = {
+    probability: number;
+    protocol: string;
 };
-export type Protocol = {
-    readonly allowPreviousPhase: boolean;
-    readonly allowSkipPhase: boolean;
-    readonly randomize: boolean;
-    readonly phases: readonly ProtocolPhase[];
+export type RawProtocol = {
+    allowPreviousPhase?: boolean;
+    allowSkipPhase?: boolean;
+    randomize?: boolean;
+    phases: RawPhase[];
 };
-export type ProtocolPhase = {
-    readonly allowPreviousQuestion: boolean;
-    readonly allowSkipQuestion: boolean;
-    readonly randomize: boolean;
-    readonly questions: readonly PhaseQuestion[];
+export type RawPhase = {
+    allowPreviousQuestion?: boolean;
+    allowSkipQuestion?: boolean;
+    randomize?: boolean;
+    questions: RawQuestion[];
 };
-export type PhaseQuestion = {
-    readonly randomize: boolean;
-    readonly img: Image;
-    readonly options: readonly Image[];
+export type RawQuestion = {
+    randomize?: boolean;
+    img: RawImage;
+    options: RawOption[];
 };
-export type Image = {
-    readonly src: string;
-    readonly alt: string;
-    readonly correct?: boolean;
+export type RawOption = RawImage & {
+    correct?: boolean;
+};
+export type RawImage = {
+    src: string;
+    alt: string;
 };

--- a/packages/config/types/types.d.ts
+++ b/packages/config/types/types.d.ts
@@ -1,18 +1,25 @@
 export type PoCoPIConfig = {
-    readonly groups: Record<string, Group>;
-    readonly protocols: Record<string, Protocol>;
+    readonly groups: Readonly<Record<string, Group>>;
+    readonly protocols: Readonly<Record<string, Protocol>>;
 };
 export type Group = {
     readonly probability: number;
     readonly protocol: string;
 };
 export type Protocol = {
+    readonly allowPreviousPhase: boolean;
+    readonly allowSkipPhase: boolean;
+    readonly randomize: boolean;
     readonly phases: readonly ProtocolPhase[];
 };
 export type ProtocolPhase = {
+    readonly allowPreviousQuestion: boolean;
+    readonly allowSkipQuestion: boolean;
+    readonly randomize: boolean;
     readonly questions: readonly PhaseQuestion[];
 };
 export type PhaseQuestion = {
+    readonly randomize: boolean;
     readonly img: Image;
     readonly options: readonly Image[];
 };


### PR DESCRIPTION
Added the following configuration fields:

1. For protocols:
- `allowPreviousPhase` (boolean): allows the user to go back to the previous phase. Default: `true`.
- `allowSkipPhase` (boolean): allows the user to skip the current phase without finishing it. Default: `true`.
- `randomize` (boolean): randomizes the order of the phases when set to `true`. Default: `false`.

2. For phases:
- `allowPreviousQuestion` (boolean): allows the user to go back to the previous question. Default: `true`.
- `allowSkipQuestion` (boolean): allows the user to skip the current question without finishing it. Default: `true`.
- `randomize` (boolean): randomizes the order of the questions when set to `true`. Default: `false`.

3. For questions:
- `randomize` (boolean): randomizes the order of the options when set to `true`. Default: `false`.