### PR TITLE
Config: personalizacion de titulo y descripcion del sitio web, y pre-test y post-test forms

### DIFF
--- a/config/config-schema.json
+++ b/config/config-schema.json
@@ -13,6 +13,12 @@
       "description": "The description of the web app.",
       "minLength": 1
     },
+    "preTestForm": {
+      "$ref": "#/$defs/form"
+    },
+    "postTestForm": {
+      "$ref": "#/$defs/form"
+    },
     "groups": {
       "type": "object",
       "description": "List of test groups.",
@@ -51,7 +57,7 @@
       "description": "List of questions the test phases will use.",
       "patternProperties": {
         "^([\\w-]+)$": {
-          "$ref": "#/$defs/question"
+          "$ref": "#/$defs/phase-question"
         }
       },
       "minProperties": 1,
@@ -61,8 +67,7 @@
   "required": [
     "title",
     "description",
-    "groups",
-    "protocols"
+    "groups"
   ],
   "additionalProperties": false,
   "$defs": {
@@ -167,7 +172,7 @@
           "items": {
             "oneOf": [
               {
-                "$ref": "#/$defs/question"
+                "$ref": "#/$defs/phase-question"
               },
               {
                 "type": "string",
@@ -226,7 +231,7 @@
       ],
       "additionalProperties": false
     },
-    "question": {
+    "phase-question": {
       "type": "object",
       "description": "A test question.",
       "properties": {
@@ -235,7 +240,7 @@
           "description": "Whether to randomize the order of the options or not.",
           "default": false
         },
-        "img": {
+        "image": {
           "$ref": "#/$defs/image"
         },
         "options": {
@@ -248,10 +253,277 @@
         }
       },
       "required": [
-        "img",
+        "image",
         "options"
       ],
       "additionalProperties": false
+    },
+    "question-select-multiple": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The question type.",
+          "enum": [
+            "select-multiple"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "description": "The list of options.",
+          "items": {
+            "type": "object",
+            "description": "An option.",
+            "properties": {
+              "text": {
+                "type": "string",
+                "description": "The options's text.",
+                "minLength": 1
+              },
+              "image": {
+                "$ref": "#/$defs/image"
+              }
+            },
+            "minProperties": 1,
+            "additionalProperties": false
+          },
+          "minItems": 2
+        },
+        "min": {
+          "type": "integer",
+          "description": "The minimum number of options to select.",
+          "minimum": 0
+        },
+        "max": {
+          "type": "integer",
+          "description": "The maximum number of options to select."
+        }
+      },
+      "required": [
+        "type",
+        "options",
+        "min",
+        "max"
+      ]
+    },
+    "question-select-one": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The question type.",
+          "enum": [
+            "select-one"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "description": "The list of options.",
+          "items": {
+            "type": "object",
+            "description": "An option.",
+            "properties": {
+              "text": {
+                "type": "string",
+                "description": "The options's text.",
+                "minLength": 1
+              },
+              "image": {
+                "$ref": "#/$defs/image"
+              }
+            },
+            "minProperties": 1,
+            "additionalProperties": false
+          },
+          "minItems": 2
+        }
+      },
+      "required": [
+        "type",
+        "options"
+      ]
+    },
+    "question-number": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The question type.",
+          "enum": [
+            "number"
+          ]
+        },
+        "placeholder": {
+          "type": "string",
+          "description": "Placeholder text to be shown when the question hasn't been answered yet.",
+          "minLength": 1
+        },
+        "min": {
+          "type": "number",
+          "description": "The minimum number allowed."
+        },
+        "max": {
+          "type": "number",
+          "description": "The maximum number allowed."
+        },
+        "step": {
+          "type": "number",
+          "description": "The increment interval when using the arrow buttons/keys.",
+          "exclusiveMinimum": 0
+        }
+      },
+      "required": [
+        "type",
+        "placeholder",
+        "min",
+        "max",
+        "step"
+      ]
+    },
+    "question-slider": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The question type.",
+          "enum": [
+            "slider"
+          ]
+        },
+        "min": {
+          "type": "number",
+          "description": "The minimum number allowed."
+        },
+        "max": {
+          "type": "number",
+          "description": "The maximum number allowed."
+        },
+        "step": {
+          "type": "number",
+          "description": "The increment interval for the slider.",
+          "exclusiveMinimum": 0
+        }
+      },
+      "required": [
+        "type",
+        "min",
+        "max",
+        "step"
+      ]
+    },
+    "question-text-short": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The question type.",
+          "enum": [
+            "text-short"
+          ]
+        },
+        "placeholder": {
+          "type": "string",
+          "description": "Placeholder text to be shown when the question hasn't been answered yet.",
+          "minLength": 1
+        },
+        "minLength": {
+          "type": "integer",
+          "description": "The minimum length of the answer.",
+          "minimum": 1
+        },
+        "maxLength": {
+          "type": "integer",
+          "description": "The maximum length of the answer."
+        }
+      },
+      "required": [
+        "type",
+        "placeholder",
+        "minLength",
+        "maxLength"
+      ]
+    },
+    "question-text-long": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The question type.",
+          "enum": [
+            "text-long"
+          ]
+        },
+        "placeholder": {
+          "type": "string",
+          "description": "Placeholder text to be shown when the question hasn't been answered yet.",
+          "minLength": 1
+        },
+        "minLength": {
+          "type": "integer",
+          "description": "The minimum length of the answer.",
+          "minimum": 1
+        },
+        "maxLength": {
+          "type": "integer",
+          "description": "The maximum length of the answer."
+        }
+      },
+      "required": [
+        "type",
+        "placeholder",
+        "minLength",
+        "maxLength"
+      ]
+    },
+    "form": {
+      "type": "object",
+      "description": "Structure of the form.",
+      "properties": {
+        "questions": {
+          "type": "array",
+          "description": "List of questions.",
+          "items": {
+            "$ref": "#/$defs/form-question"
+          }
+        }
+      }
+    },
+    "form-question": {
+      "type": "object",
+      "description": "A form question.",
+      "allOf": [
+        {
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "The question's text.",
+              "minLength": 1
+            },
+            "image": {
+              "$ref": "#/$defs/image"
+            }
+          },
+          "required": [
+            "text"
+          ]
+        },
+        {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/question-select-multiple"
+            },
+            {
+              "$ref": "#/$defs/question-select-one"
+            },
+            {
+              "$ref": "#/$defs/question-number"
+            },
+            {
+              "$ref": "#/$defs/question-slider"
+            },
+            {
+              "$ref": "#/$defs/question-text-short"
+            },
+            {
+              "$ref": "#/$defs/question-text-long"
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/config/config-schema.json
+++ b/config/config-schema.json
@@ -478,9 +478,13 @@
           "description": "List of questions.",
           "items": {
             "$ref": "#/$defs/form-question"
-          }
+          },
+          "minItems": 1
         }
-      }
+      },
+      "required": [
+        "questions"
+      ]
     },
     "form-question": {
       "type": "object",

--- a/config/config-schema.json
+++ b/config/config-schema.json
@@ -3,6 +3,16 @@
   "title": "JSON schema for PoCoPI's configuration file.",
   "type": "object",
   "properties": {
+    "title": {
+      "type": "string",
+      "description": "The tile of the web app.",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string",
+      "description": "The description of the web app.",
+      "minLength": 1
+    },
     "groups": {
       "type": "object",
       "description": "List of test groups.",
@@ -49,6 +59,8 @@
     }
   },
   "required": [
+    "title",
+    "description",
     "groups",
     "protocols"
   ],

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,5 +1,8 @@
 # $schema: ./config-schema.json
 
+title: PoCoPI
+description: Proof of Concept of Psycho-Informatics.
+
 groups:
   control:
     probability: 0.3

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,6 +3,90 @@
 title: PoCoPI
 description: Proof of Concept of Psycho-Informatics.
 
+preTestForm:
+  questions:
+    - text: Multiple selection question
+      type: select-multiple
+      options:
+        - text: Option 1
+        - text: Option 2
+        - text: Option 3
+        - text: Option 4
+        - text: Option 5
+      min: 1
+      max: 3
+    - text: Single choice question
+      type: select-one
+      options:
+        - text: Option 1
+        - text: Option 2
+        - text: Option 3
+        - text: Option 4
+        - text: Option 5
+    - text: Number input
+      type: number
+      placeholder: Answer here
+      min: 1
+      max: 2
+      step: 0.1
+    - text: Slider question
+      type: slider
+      min: 1
+      max: 10
+      step: 1
+    - text: Short text question
+      type: text-short
+      placeholder: Answer here
+      minLength: 1
+      maxLength: 50
+    - text: Long text question
+      type: text-long
+      placeholder: Answer here
+      minLength: 1
+      maxLength: 400
+
+postTestForm:
+  questions:
+    - text: Multiple selection question
+      type: select-multiple
+      options:
+        - text: Option 1
+        - text: Option 2
+        - text: Option 3
+        - text: Option 4
+        - text: Option 5
+      min: 1
+      max: 3
+    - text: Single choice question
+      type: select-one
+      options:
+        - text: Option 1
+        - text: Option 2
+        - text: Option 3
+        - text: Option 4
+        - text: Option 5
+    - text: Number input
+      type: number
+      placeholder: Answer here
+      min: 1
+      max: 2
+      step: 0.1
+    - text: Slider question
+      type: slider
+      min: 1
+      max: 10
+      step: 1
+    - text: Short text question
+      type: text-short
+      placeholder: Answer here
+      minLength: 1
+      maxLength: 50
+    - text: Long text question
+      type: text-long
+      placeholder: Answer here
+      minLength: 1
+      maxLength: 400
+
 groups:
   control:
     probability: 0.3
@@ -22,7 +106,7 @@ protocols:
     phases:
       - control-phase1
       - questions:
-        - img:
+        - image:
             src: control3.webp
             alt: question image
           options:
@@ -39,7 +123,7 @@ protocols:
               alt: option 5
             - src: control3_option6.webp
               alt: option 6
-        - img:
+        - image:
             src: control4.webp
             alt: question image
           options:
@@ -59,7 +143,7 @@ protocols:
   groupA:
     phases:
       - questions:
-        - img:
+        - image:
             src: groupA1.webp
             alt: question image
           options:
@@ -76,7 +160,7 @@ protocols:
               alt: option 5
             - src: groupA1_option6.webp
               alt: option 6
-        - img:
+        - image:
             src: groupA2.webp
             alt: question image
           options:
@@ -94,7 +178,7 @@ protocols:
             - src: groupA2_option6.webp
               alt: option 6
       - questions:
-        - img:
+        - image:
             src: groupA3.webp
             alt: question image
           options:
@@ -111,7 +195,7 @@ protocols:
               alt: option 5
             - src: groupA3_option6.webp
               alt: option 6
-        - img:
+        - image:
             src: groupA4.webp
             alt: question image
           options:
@@ -131,7 +215,7 @@ protocols:
   groupB:
     phases:
       - questions:
-        - img:
+        - image:
             src: groupB1.webp
             alt: question image
           options:
@@ -148,7 +232,7 @@ protocols:
               alt: option 5
             - src: groupB1_option6.webp
               alt: option 6
-        - img:
+        - image:
             src: groupB2.webp
             alt: question image
           options:
@@ -166,7 +250,7 @@ protocols:
             - src: groupB2_option6.webp
               alt: option 6
       - questions:
-        - img:
+        - image:
             src: groupB3.webp
             alt: question image
           options:
@@ -183,7 +267,7 @@ protocols:
               alt: option 5
             - src: groupB3_option6.webp
               alt: option 6
-        - img:
+        - image:
             src: groupB4.webp
             alt: question image
           options:
@@ -210,7 +294,7 @@ protocols:
         randomize: true
         questions:
           - randomize: true
-            img:
+            image:
               src: groupB1.webp
               alt: question image
             options:
@@ -228,7 +312,7 @@ protocols:
               - src: groupB1_option6.webp
                 alt: option 6
           - randomize: true
-            img:
+            image:
               src: groupB2.webp
               alt: question image
             options:
@@ -250,7 +334,7 @@ protocols:
         randomize: true
         questions:
           - randomize: true
-            img:
+            image:
               src: groupA1.webp
               alt: question image
             options:
@@ -268,7 +352,7 @@ protocols:
               - src: groupA1_option6.webp
                 alt: option 6
           - randomize: true
-            img:
+            image:
               src: groupA2.webp
               alt: question image
             options:
@@ -291,7 +375,7 @@ phases:
   control-phase1:
     questions:
       - control-phase1-question1
-      - img:
+      - image:
           src: control2.webp
           alt: question image
         options:
@@ -311,7 +395,7 @@ phases:
 
 questions:
   control-phase1-question1:
-    img:
+    image:
       src: control1.webp
       alt: question image
     options:

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -29,10 +29,15 @@ const defaults = Object.freeze({
 });
 
 export class Config {
+    public readonly title: string;
+    public readonly description: string;
+
     private readonly groups: readonly FlatRawGroupWithLabel[];
     private readonly probabilitySums: readonly Decimal[];
 
     public constructor(config: FlatRawConfig) {
+        this.title = config.title;
+        this.description = config.description;
         this.groups = Object.freeze(parseGroups(config));
 
         const probabilitySums: Decimal[] = [];

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -4,8 +4,10 @@ import {
     FlatRawGroupWithLabel,
     FlatRawPhase,
     FlatRawProtocol,
+    FormQuestionType,
+    RawForm, RawFormOption, RawFormQuestion,
     RawOption,
-    RawQuestion,
+    RawPhaseQuestion,
 } from "./raw-types";
 import { shuffle } from "./shuffle";
 
@@ -22,7 +24,7 @@ const defaults = Object.freeze({
     } satisfies Partial<FlatRawPhase>),
     question: Object.freeze({
         randomize: false,
-    } satisfies Partial<RawQuestion>),
+    } satisfies Partial<RawPhaseQuestion>),
     option: Object.freeze({
         correct: false,
     } satisfies Partial<RawOption>),
@@ -31,6 +33,8 @@ const defaults = Object.freeze({
 export class Config {
     public readonly title: string;
     public readonly description: string;
+    public readonly preTestForm?: Form;
+    public readonly postTestForm?: Form;
 
     private readonly groups: readonly FlatRawGroupWithLabel[];
     private readonly probabilitySums: readonly Decimal[];
@@ -38,6 +42,14 @@ export class Config {
     public constructor(config: FlatRawConfig) {
         this.title = config.title;
         this.description = config.description;
+
+        if (config.preTestForm) {
+            this.preTestForm = makeForm(config.preTestForm);
+        }
+        if (config.postTestForm) {
+            this.postTestForm = makeForm(config.postTestForm);
+        }
+
         this.groups = Object.freeze(parseGroups(config));
 
         const probabilitySums: Decimal[] = [];
@@ -77,6 +89,77 @@ export class Config {
     }
 }
 
+function makeForm(form: RawForm): Form {
+    return Object.freeze({
+        questions: Object.freeze(form.questions.map(makeFormQuestion)),
+    });
+}
+
+function makeFormQuestion(question: RawFormQuestion): FormQuestion {
+    switch (question.type) {
+        case FormQuestionType.SELECT_MULTIPLE:
+            return Object.freeze({
+                text: question.text,
+                ...question.image && { image: Object.freeze(question.image) },
+                type: question.type,
+                options: Object.freeze(question.options.map(makeFormOption)),
+                min: question.min,
+                max: question.max,
+            });
+        case FormQuestionType.SELECT_ONE:
+            return Object.freeze({
+                text: question.text,
+                ...question.image && { image: Object.freeze(question.image) },
+                type: question.type,
+                options: Object.freeze(question.options.map(makeFormOption)),
+            });
+        case FormQuestionType.NUMBER:
+            return Object.freeze({
+                text: question.text,
+                ...question.image && { image: Object.freeze(question.image) },
+                type: question.type,
+                placeholder: question.placeholder,
+                min: question.min,
+                max: question.max,
+                step: question.step,
+            });
+        case FormQuestionType.SLIDER:
+            return Object.freeze({
+                text: question.text,
+                ...question.image && { image: Object.freeze(question.image) },
+                type: question.type,
+                min: question.min,
+                max: question.max,
+                step: question.step,
+            });
+        case FormQuestionType.TEXT_SHORT:
+            return Object.freeze({
+                text: question.text,
+                ...question.image && { image: Object.freeze(question.image) },
+                type: question.type,
+                placeholder: question.placeholder,
+                minLength: question.minLength,
+                maxLength: question.maxLength,
+            });
+        case FormQuestionType.TEXT_LONG:
+            return Object.freeze({
+                text: question.text,
+                ...question.image && { image: Object.freeze(question.image) },
+                type: question.type,
+                placeholder: question.placeholder,
+                minLength: question.minLength,
+                maxLength: question.maxLength,
+            });
+    }
+}
+
+function makeFormOption(option: RawFormOption): FormOption {
+    return Object.freeze({
+        ...option.text && { text: option.text },
+        ...option.image && { image: Object.freeze(option.image) },
+    });
+}
+
 function parseGroups(config: FlatRawConfig): readonly FlatRawGroupWithLabel[] {
     const groups = Object.entries(config.groups)
         .map<FlatRawGroupWithLabel>(([label, group]) => ({
@@ -108,7 +191,7 @@ function makeProtocol(protocol: FlatRawProtocol): Protocol {
 
 function makePhase(phase: FlatRawPhase): Phase {
     const randomize = phase.randomize ?? defaults.phase.randomize;
-    const questions = phase.questions.map(makeQuestion);
+    const questions = phase.questions.map(makePhaseQuestion);
 
     return Object.freeze({
         allowPreviousQuestion: phase.allowPreviousQuestion ?? defaults.phase.allowPreviousQuestion,
@@ -117,22 +200,85 @@ function makePhase(phase: FlatRawPhase): Phase {
     });
 }
 
-function makeQuestion(question: RawQuestion): Question {
+function makePhaseQuestion(question: RawPhaseQuestion): Question {
     const randomize = question.randomize ?? defaults.question.randomize;
     const options = question.options.map(makeOption);
 
     return Object.freeze({
-        image: Object.freeze(question.img),
+        image: Object.freeze(question.image),
         options: Object.freeze(randomize ? shuffle(options) : options),
     });
 }
 
 function makeOption(option: RawOption): Option {
     return Object.freeze({
-        ...defaults.option,
-        ...option,
+        src: option.src,
+        alt: option.alt,
+        correct: option.correct ?? defaults.option.correct,
     });
 }
+
+export type Form = {
+    readonly questions: readonly FormQuestion[];
+};
+
+export type FormQuestion = {
+    readonly text: string;
+    readonly image?: Image;
+} & (
+    | FormQuestionSelectMultiple
+    | FormQuestionSelectOne
+    | FormQuestionNumber
+    | FormQuestionSlider
+    | FormQuestionTextShort
+    | FormQuestionTextLong
+    );
+
+export type FormQuestionSelectMultiple = {
+    readonly type: FormQuestionType.SELECT_MULTIPLE;
+    readonly options: readonly FormOption[];
+    readonly min: number;
+    readonly max: number;
+};
+
+export type FormQuestionSelectOne = {
+    readonly type: FormQuestionType.SELECT_ONE;
+    readonly options: readonly FormOption[];
+};
+
+export type FormQuestionNumber = {
+    readonly type: FormQuestionType.NUMBER;
+    readonly placeholder: string;
+    readonly min: number;
+    readonly max: number;
+    readonly step: number;
+};
+
+export type FormQuestionSlider = {
+    readonly type: FormQuestionType.SLIDER;
+    readonly min: number;
+    readonly max: number;
+    readonly step: number;
+};
+
+export type FormQuestionTextShort = {
+    readonly type: FormQuestionType.TEXT_SHORT;
+    readonly placeholder: string;
+    readonly minLength: number;
+    readonly maxLength: number;
+};
+
+export type FormQuestionTextLong = {
+    readonly type: FormQuestionType.TEXT_LONG;
+    readonly placeholder: string;
+    readonly minLength: number;
+    readonly maxLength: number;
+};
+
+export type FormOption = {
+    readonly text?: string;
+    readonly image?: Image;
+};
 
 export type Group = {
     readonly label: string;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -154,7 +154,7 @@ function validateConfig(config: FlatRawConfig): FlatRawConfig {
         }
 
         question.image.src = questionImagePath;
-        usedImages.set(questionImage, `${path}.img`);
+        usedImages.set(questionImage, `${path}.image`);
 
         let foundCorrect = -1;
 

--- a/packages/config/src/raw-types.ts
+++ b/packages/config/src/raw-types.ts
@@ -1,8 +1,12 @@
 export type FlatRawConfig = {
+    title: string;
+    description: string;
     groups: Record<string, FlatRawGroup>;
 };
 
 export type RawConfig = {
+    title: string;
+    description: string;
     groups: Record<string, RawGroup>;
     protocols?: Record<string, RawProtocol>;
     phases?: Record<string, RawPhase>;

--- a/packages/config/src/raw-types.ts
+++ b/packages/config/src/raw-types.ts
@@ -1,16 +1,91 @@
 export type FlatRawConfig = {
     title: string;
     description: string;
+    preTestForm?: RawForm;
+    postTestForm?: RawForm;
     groups: Record<string, FlatRawGroup>;
 };
 
 export type RawConfig = {
     title: string;
     description: string;
+    preTestForm?: RawForm;
+    postTestForm?: RawForm;
     groups: Record<string, RawGroup>;
     protocols?: Record<string, RawProtocol>;
     phases?: Record<string, RawPhase>;
-    questions?: Record<string, RawQuestion>;
+    questions?: Record<string, RawPhaseQuestion>;
+};
+
+export type RawForm = {
+    questions: RawFormQuestion[];
+};
+
+export enum FormQuestionType {
+    SELECT_MULTIPLE = "select-multiple",
+    SELECT_ONE = "select-one",
+    NUMBER = "number",
+    SLIDER = "slider",
+    TEXT_SHORT = "text-short",
+    TEXT_LONG = "text-long",
+}
+
+export type RawFormQuestion = {
+    text: string;
+    image?: RawImage;
+} & (
+    | RawFormQuestionSelectMultiple
+    | RawFormQuestionSelectOne
+    | RawFormQuestionNumber
+    | RawFormQuestionSlider
+    | RawFormQuestionTextShort
+    | RawFormQuestionTextLong
+    );
+
+export type RawFormQuestionSelectMultiple = {
+    type: FormQuestionType.SELECT_MULTIPLE;
+    options: RawFormOption[];
+    min: number;
+    max: number;
+};
+
+export type RawFormQuestionSelectOne = {
+    type: FormQuestionType.SELECT_ONE;
+    options: RawFormOption[];
+};
+
+export type RawFormQuestionNumber = {
+    type: FormQuestionType.NUMBER;
+    placeholder: string;
+    min: number;
+    max: number;
+    step: number;
+};
+
+export type RawFormQuestionSlider = {
+    type: FormQuestionType.SLIDER;
+    min: number;
+    max: number;
+    step: number;
+};
+
+export type RawFormQuestionTextShort = {
+    type: FormQuestionType.TEXT_SHORT;
+    placeholder: string;
+    minLength: number;
+    maxLength: number;
+};
+
+export type RawFormQuestionTextLong = {
+    type: FormQuestionType.TEXT_LONG;
+    placeholder: string;
+    minLength: number;
+    maxLength: number;
+};
+
+export type RawFormOption = {
+    text?: string;
+    image?: RawImage;
 };
 
 export type FlatRawGroupWithLabel = FlatRawGroup & {
@@ -38,19 +113,19 @@ export type RawProtocol = {
 };
 
 export type FlatRawPhase = Omit<RawPhase, "questions"> & {
-    questions: RawQuestion[];
+    questions: RawPhaseQuestion[];
 };
 
 export type RawPhase = {
     allowPreviousQuestion?: boolean;
     allowSkipQuestion?: boolean;
     randomize?: boolean;
-    questions: Array<RawQuestion | string>;
+    questions: Array<RawPhaseQuestion | string>;
 };
 
-export type RawQuestion = {
+export type RawPhaseQuestion = {
     randomize?: boolean;
-    img: RawImage;
+    image: RawImage;
     options: RawOption[];
 };
 

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2024",
+    "target": "ES6",
     "module": "CommonJS",
     "sourceRoot": "./src",
     "outDir": "./dist",

--- a/packages/config/types/config.d.ts
+++ b/packages/config/types/config.d.ts
@@ -1,6 +1,8 @@
 import Decimal from "decimal.js";
 import { FlatRawConfig } from "./raw-types";
 export declare class Config {
+    readonly title: string;
+    readonly description: string;
     private readonly groups;
     private readonly probabilitySums;
     constructor(config: FlatRawConfig);

--- a/packages/config/types/config.d.ts
+++ b/packages/config/types/config.d.ts
@@ -1,13 +1,61 @@
 import Decimal from "decimal.js";
-import { FlatRawConfig } from "./raw-types";
+import { FlatRawConfig, FormQuestionType } from "./raw-types";
 export declare class Config {
     readonly title: string;
     readonly description: string;
+    readonly preTestForm?: Form;
+    readonly postTestForm?: Form;
     private readonly groups;
     private readonly probabilitySums;
     constructor(config: FlatRawConfig);
     sampleGroup(): Group;
 }
+export type Form = {
+    readonly questions: readonly FormQuestion[];
+};
+export type FormQuestion = {
+    readonly text: string;
+    readonly image?: Image;
+} & (FormQuestionSelectMultiple | FormQuestionSelectOne | FormQuestionNumber | FormQuestionSlider | FormQuestionTextShort | FormQuestionTextLong);
+export type FormQuestionSelectMultiple = {
+    readonly type: FormQuestionType.SELECT_MULTIPLE;
+    readonly options: readonly FormOption[];
+    readonly min: number;
+    readonly max: number;
+};
+export type FormQuestionSelectOne = {
+    readonly type: FormQuestionType.SELECT_ONE;
+    readonly options: readonly FormOption[];
+};
+export type FormQuestionNumber = {
+    readonly type: FormQuestionType.NUMBER;
+    readonly placeholder: string;
+    readonly min: number;
+    readonly max: number;
+    readonly step: number;
+};
+export type FormQuestionSlider = {
+    readonly type: FormQuestionType.SLIDER;
+    readonly min: number;
+    readonly max: number;
+    readonly step: number;
+};
+export type FormQuestionTextShort = {
+    readonly type: FormQuestionType.TEXT_SHORT;
+    readonly placeholder: string;
+    readonly minLength: number;
+    readonly maxLength: number;
+};
+export type FormQuestionTextLong = {
+    readonly type: FormQuestionType.TEXT_LONG;
+    readonly placeholder: string;
+    readonly minLength: number;
+    readonly maxLength: number;
+};
+export type FormOption = {
+    readonly text?: string;
+    readonly image?: Image;
+};
 export type Group = {
     readonly label: string;
     readonly probability: Decimal;

--- a/packages/config/types/index.d.ts
+++ b/packages/config/types/index.d.ts
@@ -1,3 +1,4 @@
 import { Config } from "./config";
 export declare const config: Config;
 export * from "./config";
+export { FormQuestionType } from "./raw-types";

--- a/packages/config/types/raw-types.d.ts
+++ b/packages/config/types/raw-types.d.ts
@@ -1,15 +1,73 @@
 export type FlatRawConfig = {
     title: string;
     description: string;
+    preTestForm?: RawForm;
+    postTestForm?: RawForm;
     groups: Record<string, FlatRawGroup>;
 };
 export type RawConfig = {
     title: string;
     description: string;
+    preTestForm?: RawForm;
+    postTestForm?: RawForm;
     groups: Record<string, RawGroup>;
     protocols?: Record<string, RawProtocol>;
     phases?: Record<string, RawPhase>;
-    questions?: Record<string, RawQuestion>;
+    questions?: Record<string, RawPhaseQuestion>;
+};
+export type RawForm = {
+    questions: RawFormQuestion[];
+};
+export declare enum FormQuestionType {
+    SELECT_MULTIPLE = "select-multiple",
+    SELECT_ONE = "select-one",
+    NUMBER = "number",
+    SLIDER = "slider",
+    TEXT_SHORT = "text-short",
+    TEXT_LONG = "text-long"
+}
+export type RawFormQuestion = {
+    text: string;
+    image?: RawImage;
+} & (RawFormQuestionSelectMultiple | RawFormQuestionSelectOne | RawFormQuestionNumber | RawFormQuestionSlider | RawFormQuestionTextShort | RawFormQuestionTextLong);
+export type RawFormQuestionSelectMultiple = {
+    type: FormQuestionType.SELECT_MULTIPLE;
+    options: RawFormOption[];
+    min: number;
+    max: number;
+};
+export type RawFormQuestionSelectOne = {
+    type: FormQuestionType.SELECT_ONE;
+    options: RawFormOption[];
+};
+export type RawFormQuestionNumber = {
+    type: FormQuestionType.NUMBER;
+    placeholder: string;
+    min: number;
+    max: number;
+    step: number;
+};
+export type RawFormQuestionSlider = {
+    type: FormQuestionType.SLIDER;
+    min: number;
+    max: number;
+    step: number;
+};
+export type RawFormQuestionTextShort = {
+    type: FormQuestionType.TEXT_SHORT;
+    placeholder: string;
+    minLength: number;
+    maxLength: number;
+};
+export type RawFormQuestionTextLong = {
+    type: FormQuestionType.TEXT_LONG;
+    placeholder: string;
+    minLength: number;
+    maxLength: number;
+};
+export type RawFormOption = {
+    text?: string;
+    image?: RawImage;
 };
 export type FlatRawGroupWithLabel = FlatRawGroup & {
     label: string;
@@ -31,17 +89,17 @@ export type RawProtocol = {
     phases: Array<RawPhase | string>;
 };
 export type FlatRawPhase = Omit<RawPhase, "questions"> & {
-    questions: RawQuestion[];
+    questions: RawPhaseQuestion[];
 };
 export type RawPhase = {
     allowPreviousQuestion?: boolean;
     allowSkipQuestion?: boolean;
     randomize?: boolean;
-    questions: Array<RawQuestion | string>;
+    questions: Array<RawPhaseQuestion | string>;
 };
-export type RawQuestion = {
+export type RawPhaseQuestion = {
     randomize?: boolean;
-    img: RawImage;
+    image: RawImage;
     options: RawOption[];
 };
 export type RawOption = RawImage & {

--- a/packages/config/types/raw-types.d.ts
+++ b/packages/config/types/raw-types.d.ts
@@ -1,7 +1,11 @@
 export type FlatRawConfig = {
+    title: string;
+    description: string;
     groups: Record<string, FlatRawGroup>;
 };
 export type RawConfig = {
+    title: string;
+    description: string;
     groups: Record<string, RawGroup>;
     protocols?: Record<string, RawProtocol>;
     phases?: Record<string, RawPhase>;


### PR DESCRIPTION
Added configuration options for page title and description, and the pre-test and post-test forms.

Example:
```yaml
title: PoCoPI
description: >
  Proof of Concept of Psycho-Informatics. This may have multiple lines if needed.

  Empty line before => this is in a new line

preTestForm:
  questions:                              # required, at least 1 item
    - text: Multiple selection question   # required
      image:                              # optional, may be shown alongside 'text' in the frontend
        src: question1.png                # required, only filename
        alt: Question image               # required for accessibility
      type: select-multiple               # required, question structure changes based on this
      options:                            # required, at last 2 items
        - text: Option 1                  # either 'text', 'image' or both must be present
          image:
            src: question1-option1.png
            alt: Option 1 image
        - text: Option 2
        - text: Option 3
        - text: Option 4
        - text: Option 5
      min: 1                              # all question options are required
      max: 3
    - text: Single choice question
      type: select-one
      options:
        - text: Option 1
        - text: Option 2
        - text: Option 3
        - text: Option 4
        - text: Option 5
    - text: Number input
      type: number
      placeholder: Answer here
      min: 1
      max: 2
      step: 0.1
    - text: Slider question
      type: slider
      min: 1
      max: 10
      step: 1
    - text: Short text question
      type: text-short
      placeholder: Answer here
      minLength: 1
      maxLength: 50
    - text: Long text question
      type: text-long
      placeholder: Answer here
      minLength: 1
      maxLength: 400
```